### PR TITLE
Add Thai recognizers

### DIFF
--- a/customized_recognizers/thai_recognizers.py
+++ b/customized_recognizers/thai_recognizers.py
@@ -1,0 +1,70 @@
+from presidio_analyzer import PatternRecognizer, Pattern, EntityRecognizer, RecognizerResult
+from presidio_analyzer.nlp_engine import NlpArtifacts
+
+
+class ThaiNationalIDRecognizer(PatternRecognizer):
+    """Recognize Thai national ID numbers (13 digits)."""
+
+    def __init__(self) -> None:
+        pattern = Pattern(
+            name="Thai National ID",
+            regex=r"\b\d{13}\b",
+            score=0.6,
+        )
+        super().__init__(
+            supported_entity="TH_ID",
+            patterns=[pattern],
+            name="ThaiNationalIDRecognizer",
+            supported_language="th",
+            context=["บัตรประชาชน"],
+        )
+
+
+class ThaiPhoneRecognizer(PatternRecognizer):
+    """Recognize Thai phone numbers in formats 0X-XXXX-XXXX or 0X XXXX XXXX."""
+
+    def __init__(self) -> None:
+        phone_pattern = Pattern(
+            name="Thai Phone Number",
+            regex=r"\b0\d[- ]\d{4}[- ]\d{4}\b",
+            score=0.6,
+        )
+        super().__init__(
+            supported_entity="TH_PHONE",
+            patterns=[phone_pattern],
+            name="ThaiPhoneRecognizer",
+            supported_language="th",
+            context=["โทรศัพท์"],
+        )
+
+
+class ThaiPersonNameRecognizer(EntityRecognizer):
+    """Recognize Thai person names using NER results from the NLP engine."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            supported_entities=["TH_PERSON"],
+            name="ThaiPersonNameRecognizer",
+            supported_language="th",
+            context=["ชื่อ"],
+        )
+
+    def load(self) -> None:
+        """No external resources needed."""
+        return None
+
+    def analyze(
+        self, text: str, entities: list[str], nlp_artifacts: NlpArtifacts
+    ) -> list[RecognizerResult]:
+        results: list[RecognizerResult] = []
+        for ent in nlp_artifacts.entities:
+            if ent.label_.upper() in {"PERSON", "PER", "B-PERSON", "I-PERSON"}:
+                results.append(
+                    RecognizerResult(
+                        entity_type="TH_PERSON",
+                        start=ent.start_char,
+                        end=ent.end_char,
+                        score=0.85,
+                    )
+                )
+        return results

--- a/examples/thai_pii_example.py
+++ b/examples/thai_pii_example.py
@@ -1,0 +1,31 @@
+"""Example usage of Thai custom PII recognizers with Presidio."""
+from presidio_analyzer import AnalyzerEngine
+from customized_recognizers.thai_recognizers import (
+    ThaiNationalIDRecognizer,
+    ThaiPhoneRecognizer,
+    ThaiPersonNameRecognizer,
+)
+from utils.wrapper_presidio_analyzer import create_model_spacy
+
+
+def main():
+    text = (
+        "นายสมชาย โทรศัพท์ 09-1234-5678 เลขบัตรประชาชน 1101700201234"
+    )
+
+    # Load Thai NLP model (replace with your Thai model)
+    nlp_engine = create_model_spacy(language="th", spacy_model="th_core_news_sm")
+
+    analyzer = AnalyzerEngine(nlp_engine=nlp_engine, supported_languages=["th"])
+
+    analyzer.registry.add_recognizer(ThaiNationalIDRecognizer())
+    analyzer.registry.add_recognizer(ThaiPhoneRecognizer())
+    analyzer.registry.add_recognizer(ThaiPersonNameRecognizer())
+
+    results = analyzer.analyze(text=text, language="th")
+    for result in results:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add custom Thai Presidio recognizers for national ID, phone number, and person name
- include example script showing how to register and use them

## Testing
- `python -m py_compile customized_recognizers/thai_recognizers.py examples/thai_pii_example.py`


------
https://chatgpt.com/codex/tasks/task_b_688c79192df8832688bcd45ac47e6ef9